### PR TITLE
Add support for 'mparticle' instance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,47 @@
+{
+    "env": {
+        "browser": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            4,
+            { "SwitchCase": 1}
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "no-unneeded-ternary": [
+            "error",
+            { "defaultAssignment": false }
+        ],
+        "comma-dangle": [
+            "error",
+            "never"
+        ],
+        "curly": [
+            "error",
+            "multi-line"
+        ],
+        "comma-spacing": [
+            "error",
+            { before: false, after: true }
+        ],
+        "quote-props": [
+            "error",
+            "as-needed",
+            { keywords: false, unnecessary: true, numbers: false }
+        ],
+        "no-multi-spaces": "error",
+    }
+}

--- a/MixpanelEventForwarder.js
+++ b/MixpanelEventForwarder.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef*/
 //  Copyright 2015 mParticle, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,38 +14,39 @@
 //  limitations under the License.
 
 (function (window) {
-    var name    = 'MixpanelEventForwarder',
-    MessageType = {
-        SessionStart: 1,
-        SessionEnd  : 2,
-        PageView    : 3,
-        PageEvent   : 4,
-        CrashReport : 5,
-        OptOut      : 6,
-        Commerce    : 16
-    };
+    var name = 'MixpanelEventForwarder',
+        MessageType = {
+            SessionStart: 1,
+            SessionEnd  : 2,
+            PageView    : 3,
+            PageEvent   : 4,
+            CrashReport : 5,
+            OptOut      : 6,
+            Commerce    : 16
+        };
 
 
     var constructor = function () {
-        var self          = this,
-        isInitialized     = false,
-        forwarderSettings = null,
-        reportingService  = null,
-        isTesting         = false;
+        var self = this,
+            isInitialized = false,
+            forwarderSettings = null,
+            reportingService = null,
+            isTesting = false;
 
         self.name = name;
 
         function initForwarder(settings, service, testMode) {
             forwarderSettings = settings;
-            reportingService  = service;
-            isTesting         = testMode;
+            reportingService = service;
+            isTesting = testMode;
 
             try {
                 if (!testMode) {
+                    /* eslint-disable */
                     (function(e,b){if (!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
                     for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f)}})(document,window.mixpanel||[]);
-
-                    mixpanel.init(settings.token);
+                    /* eslint-enable */
+                    mixpanel.init(settings.token, {}, 'mparticle');
                 }
 
                 isInitialized = true;
@@ -102,10 +104,10 @@
 
             try {
                 if (window.mParticle.IdentityType.Alias == type) {
-                    mixpanel.alias(id.toString());
+                    mixpanel.mparticle.alias(id.toString());
                 }
                 else {
-                    mixpanel.identify(id.toString());
+                    mixpanel.mparticle.identify(id.toString());
                 }
 
                 return 'Successfully called identify on forwarder: ' + name;
@@ -116,11 +118,11 @@
         }
 
         function setUserAttribute(key, value) {
-            var attr  = {};
+            var attr = {};
             attr[key] = value;
 
             try {
-                mixpanel.register(attr);
+                mixpanel.mparticle.register(attr);
             }
             catch(e) {
                 return 'Can\'t call register on forwarder: ' + name + ': ' + e;
@@ -129,7 +131,7 @@
 
         function removeUserAttribute(attribute) {
             try {
-                mixpanel.unregister(attribute);
+                mixpanel.mparticle.unregister(attribute);
             }
             catch(e) {
                 return 'Can\'t call unregister on forwarder: ' + name + ': ' + e;
@@ -140,7 +142,7 @@
             event.EventAttributes = event.EventAttributes || {};
 
             try {
-                mixpanel.track(
+                mixpanel.mparticle.track(
                     event.EventName,
                     event.EventAttributes);
             }
@@ -155,17 +157,17 @@
             }
 
             try {
-                mixpanel.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
+                mixpanel.mparticle.people.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
             }
             catch (e) {
                 return 'Can\'t log commerce event on forwarder: ' + name + ': ' + e;
             }
         }
 
-        this.init                = initForwarder;
-        this.process             = processEvent;
-        this.setUserAttribute    = setUserAttribute;
-        this.setUserIdentity     = setUserIdentity;
+        this.init = initForwarder;
+        this.process = processEvent;
+        this.setUserAttribute = setUserAttribute;
+        this.setUserIdentity = setUserIdentity;
         this.removeUserAttribute = removeUserAttribute;
     };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
+/* eslint-disable no-undef*/
 describe('Mixpanel Forwarder', function () {
-
     var ReportingService = function () {
         var self   = this;
         this.id    = null;
@@ -81,46 +81,44 @@ describe('Mixpanel Forwarder', function () {
     reportService = new ReportingService();
 
     function MPMock () {
-        var self          = this;
+        var self = this;
         var calledMethods = ['alias', 'track', 'identify', 'register', 'unregister', 'trackCharge', 'clearCharges'];
-
+        this.mparticle = { people: {}, data: {}};
         for (var i = 0; i < calledMethods.length; i++) {
-            this[calledMethods[i] + 'Called'] = false;
+            this.mparticle[calledMethods[i] + 'Called'] = false;
         }
 
-        this.data = null;
-
-        this.track         = function(eventName, data) {
+        this.mparticle.track = function(eventName, data) {
             setCalledAttributes([eventName, data], 'trackCalled');
         };
 
-        this.identify      = function (data) {
+        this.mparticle.identify = function (data) {
             setCalledAttributes(data, 'identifyCalled');
         };
 
-        this.alias         = function (data) {
+        this.mparticle.alias = function (data) {
             setCalledAttributes(data, 'aliasCalled');
         };
 
-        this.register      = function (data) {
+        this.mparticle.register = function (data) {
             setCalledAttributes(data, 'registerCalled');
         };
 
-        this.unregister    = function (data) {
+        this.mparticle.unregister = function (data) {
             setCalledAttributes(data, 'unregisterCalled');
         };
 
-        this.track_charge  = function (data) {
+        this.mparticle.people.track_charge = function (data) {
             setCalledAttributes(data, 'trackChargeCalled');
         };
 
-        this.clear_charges = function (data) {
+        this.mparticle.people.clear_charges = function (data) {
             setCalledAttributes(data, 'clearChargeCalled');
         };
 
         function setCalledAttributes(data, attr) {
-            self.data  = data;
-            self[attr] = true;
+            self.mparticle.data = data;
+            self.mparticle[attr] = true;
         }
     }
 
@@ -130,9 +128,9 @@ describe('Mixpanel Forwarder', function () {
         }, reportService.cb, true);
 
         mParticle.ProductActionType = ProductActionType;
-        mParticle.EventType         = EventType;
-        mParticle.IdentityType      = IdentityType;
-        mParticle.PromotionType     = PromotionActionType;
+        mParticle.EventType = EventType;
+        mParticle.IdentityType = IdentityType;
+        mParticle.PromotionType = PromotionActionType;
     });
 
     beforeEach(function () {
@@ -140,21 +138,20 @@ describe('Mixpanel Forwarder', function () {
     });
 
     describe('Logging events', function() {
-
         it('should log event', function(done) {
             mParticle.forwarder.process({
                 EventDataType : MessageType.PageEvent,
-                EventName     : 'Test Page Event'
+                EventName : 'Test Page Event'
             });
 
-            window.mixpanel.should.have.property('trackCalled', true);
-            window.mixpanel.data.should.be.instanceof(Array).and.have.lengthOf(2);
+            window.mixpanel.mparticle.should.have.property('trackCalled', true);
+            window.mixpanel.mparticle.data.should.be.instanceof(Array).and.have.lengthOf(2);
 
-            window.mixpanel.data[0].should.be.type('string');
-            window.mixpanel.data[1].should.be.instanceof(Object);
+            window.mixpanel.mparticle.data[0].should.be.type('string');
+            window.mixpanel.mparticle.data[1].should.be.instanceof(Object);
 
-            window.mixpanel.data[0].should.be.equal('Test Page Event');
-            Should(window.mixpanel.data[1]).eql({});
+            window.mixpanel.mparticle.data[0].should.be.equal('Test Page Event');
+            Should(window.mixpanel.mparticle.data[1]).eql({});
 
             done();
         });
@@ -162,35 +159,34 @@ describe('Mixpanel Forwarder', function () {
     });
 
     describe('User events', function() {
-
         it('should alias user', function(done) {
             mParticle.forwarder.setUserIdentity('dpatel@mparticle.com', mParticle.IdentityType.Alias);
-            window.mixpanel.should.have.property('aliasCalled', true);
-            window.mixpanel.should.have.property('data', 'dpatel@mparticle.com');
+            window.mixpanel.mparticle.should.have.property('aliasCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'dpatel@mparticle.com');
 
             done();
         });
 
         it('should identify user', function(done) {
             mParticle.forwarder.setUserIdentity('dpatel@mparticle.com', mParticle.IdentityType.CustomerId);
-            window.mixpanel.should.have.property('identifyCalled', true);
-            window.mixpanel.should.have.property('data', 'dpatel@mparticle.com');
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'dpatel@mparticle.com');
 
             done();
         });
 
         it('should register a user', function(done) {
             mParticle.forwarder.setUserAttribute('email', 'dpatel@mparticle.com');
-            window.mixpanel.should.have.property('registerCalled', true);
-            window.mixpanel.data.should.be.an.instanceof(Object).and.have.property('email', 'dpatel@mparticle.com');
+            window.mixpanel.mparticle.should.have.property('registerCalled', true);
+            window.mixpanel.mparticle.data.should.be.an.instanceof(Object).and.have.property('email', 'dpatel@mparticle.com');
 
             done();
         });
 
         it('should unregister a user', function(done) {
             mParticle.forwarder.removeUserAttribute('dpatel@mparticle.com');
-            window.mixpanel.should.have.property('unregisterCalled', true);
-            window.mixpanel.should.have.property('data', 'dpatel@mparticle.com');
+            window.mixpanel.mparticle.should.have.property('unregisterCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'dpatel@mparticle.com');
 
             done();
         });
@@ -198,7 +194,6 @@ describe('Mixpanel Forwarder', function () {
     });
 
     describe('Transaction events', function() {
-
         it('should track charge event', function(done) {
             mParticle.forwarder.init({
                 includeUserAttributes: 'True',
@@ -214,15 +209,15 @@ describe('Mixpanel Forwarder', function () {
                 }
             });
 
-            window.mixpanel.should.have.property('trackChargeCalled', true);
-            window.mixpanel.should.have.property('data', 10);
+            window.mixpanel.mparticle.should.have.property('trackChargeCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 10);
 
             done();
         });
 
         it('should enfore useMixpanelPeople to charge', function(done) {
             mParticle.forwarder.init({
-                includeUserAttributes: 'True',
+                includeUserAttributes: 'True'
             }, reportService.cb, true);
 
             mParticle.forwarder.process({
@@ -234,8 +229,8 @@ describe('Mixpanel Forwarder', function () {
                 }
             });
 
-            window.mixpanel.should.have.property('trackChargeCalled', false);
-            window.mixpanel.should.have.property('data', null);
+            window.mixpanel.mparticle.should.have.property('trackChargeCalled', false);
+            window.mixpanel.mparticle.should.have.property('data', {});
 
             done();
         });


### PR DESCRIPTION
Resolves https://github.com/mParticle/mparticle-sdk-javascript-private/issues/136
This commit serves 2 functions:

1. Init using an 'mparticle' instance, which requires us to perform functions using mixpanel.mparticle.xyz('foo') rather than mixpanel.xyz('foo')
2. Fixes a bug where commerce was not being logged. Previous version had mixpanel.track_charge(), but it should be mixpanel.people.track_charge() per https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.people.track_charge

Finally - added some eslinting and fixed misc JS style issues.