### PR TITLE
Add 'main' attribute to the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist/MixpanelEventForwarder.common.js"
   ],
+  "main": "dist/MixpanelEventForwarder.common.js",
   "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-mixpanel",
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
Hello there!

We are trying to use your library as stated here:
https://docs.mparticle.com/developers/sdk/web/self-hosting/#full-initialization-examples

But we are getting the error that the package is not found, like this:
![image](https://user-images.githubusercontent.com/39386590/73356752-50222300-429b-11ea-9d2a-2e144063c4fa.png)

We have found that your `package.json` is missing the attribute `main`, which is used by node to find the file that exposes the code of the library, as specified here:
https://docs.npmjs.com/files/package.json#main

So adding this attribute will fix the import for us when using the mix panel kit. 

For more context, our application is using Angular v6 with Typescript and we already have the mParticle web-sdk imported and working.

Thanks in advance!

