### PR TITLE
Bugfix - implement onUserIdentified with userIdentificationType

### DIFF
--- a/MixpanelEventForwarder.js
+++ b/MixpanelEventForwarder.js
@@ -88,7 +88,7 @@ var mpMixpanelKit = (function (exports) {
                   }
                   else if (event.EventDataType == MessageType.Commerce &&
                       event.ProductAction &&
-                      event.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                      event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
                       reportEvent = true;
                       logCommerceEvent(event);
@@ -108,6 +108,9 @@ var mpMixpanelKit = (function (exports) {
           }
 
           function setUserIdentity(id, type) {
+              if (window.mParticle.getVersion()[0] !== '1') {
+                  return;
+              }
               if (!id) {
                   return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
               }
@@ -123,6 +126,47 @@ var mpMixpanelKit = (function (exports) {
                   else {
                       mixpanel.mparticle.identify(id.toString());
                   }
+
+                  return 'Successfully called identify on forwarder: ' + name;
+              }
+              catch (e) {
+                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+              }
+          }
+
+          function onUserIdentified(user) {
+              var idForMixpanel;
+              var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+              switch (forwarderSettings.userIdentificationType) {
+                  case 'CustomerId':
+                      idForMixpanel = userIdentities.customerid;
+                      break;
+                  case 'MPID':
+                      idForMixpanel = user.getMPID();
+                      break;
+                  case 'Other':
+                      idForMixpanel = userIdentities.other;
+                      break;
+                  case 'Other2':
+                      idForMixpanel = userIdentities.other2;
+                      break;
+                  case 'Other3':
+                      idForMixpanel = userIdentities.other3;
+                      break;
+                  case 'Other4':
+                      idForMixpanel = userIdentities.other4;
+                      break;
+                  default:
+                      idForMixpanel = userIdentities.customerid;
+                      break;
+              }
+
+              if (!isInitialized) {
+                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+              }
+
+              try {
+                  mixpanel.mparticle.identify(idForMixpanel);
 
                   return 'Successfully called identify on forwarder: ' + name;
               }
@@ -190,6 +234,7 @@ var mpMixpanelKit = (function (exports) {
           this.process = processEvent;
           this.setUserAttribute = setUserAttribute;
           this.setUserIdentity = setUserIdentity;
+          this.onUserIdentified = onUserIdentified;
           this.removeUserAttribute = removeUserAttribute;
       };
 

--- a/MixpanelEventForwarder.js
+++ b/MixpanelEventForwarder.js
@@ -1,287 +1,278 @@
 var mpMixpanelKit = (function (exports) {
-  /*!
-   * isobject <https://github.com/jonschlinkert/isobject>
-   *
-   * Copyright (c) 2014-2017, Jon Schlinkert.
-   * Released under the MIT License.
-   */
-
-  function isObject(val) {
-    return val != null && typeof val === 'object' && Array.isArray(val) === false;
-  }
-
-  /* eslint-disable no-undef*/
-  //  Copyright 2015 mParticle, Inc.
-  //
-  //  Licensed under the Apache License, Version 2.0 (the "License");
-  //  you may not use this file except in compliance with the License.
-  //  You may obtain a copy of the License at
-  //
-  //      http://www.apache.org/licenses/LICENSE-2.0
-  //
-  //  Unless required by applicable law or agreed to in writing, software
-  //  distributed under the License is distributed on an "AS IS" BASIS,
-  //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  //  See the License for the specific language governing permissions and
-  //  limitations under the License.
-      
-
-      var name = 'MixpanelEventForwarder',
-          moduleId = 10,
-          MessageType = {
-              SessionStart: 1,
-              SessionEnd  : 2,
-              PageView    : 3,
-              PageEvent   : 4,
-              CrashReport : 5,
-              OptOut      : 6,
-              Commerce    : 16
-          };
+    /* eslint-disable no-undef*/
+    //  Copyright 2015 mParticle, Inc.
+    //
+    //  Licensed under the Apache License, Version 2.0 (the "License");
+    //  you may not use this file except in compliance with the License.
+    //  You may obtain a copy of the License at
+    //
+    //      http://www.apache.org/licenses/LICENSE-2.0
+    //
+    //  Unless required by applicable law or agreed to in writing, software
+    //  distributed under the License is distributed on an "AS IS" BASIS,
+    //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    //  See the License for the specific language governing permissions and
+    //  limitations under the License.
+        var name = 'MixpanelEventForwarder',
+            moduleId = 10,
+            MessageType = {
+                SessionStart: 1,
+                SessionEnd  : 2,
+                PageView    : 3,
+                PageEvent   : 4,
+                CrashReport : 5,
+                OptOut      : 6,
+                Commerce    : 16
+            };
 
 
-      var constructor = function () {
-          var self = this,
-              isInitialized = false,
-              forwarderSettings = null,
-              reportingService = null;
+        var constructor = function () {
+            var self = this,
+                isInitialized = false,
+                forwarderSettings = null,
+                reportingService = null;
 
-          self.name = name;
+            self.name = name;
 
-          function initForwarder(settings, service, testMode) {
-              forwarderSettings = settings;
-              reportingService = service;
+            function initForwarder(settings, service, testMode) {
+                forwarderSettings = settings;
+                reportingService = service;
 
-              try {
-                  if (!testMode) {
-                      /* eslint-disable */
-                      (function(e,b){if (!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)));};}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
-                      for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d]);};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);}})(document,window.mixpanel||[]);
-                      /* eslint-enable */
-                      mixpanel.init(settings.token, {}, 'mparticle');
-                  }
+                try {
+                    if (!testMode) {
+                        /* eslint-disable */
+                        (function(e,b){if (!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)));};}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
+                        for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d]);};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);}})(document,window.mixpanel||[]);
+                        /* eslint-enable */
+                        mixpanel.init(settings.token, {}, 'mparticle');
+                    }
 
-                  isInitialized = true;
+                    isInitialized = true;
 
-                  return 'Successfully initialized: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t initialize forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully initialized: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t initialize forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function processEvent(event) {
-              var reportEvent = false;
+            function processEvent(event) {
+                var reportEvent = false;
 
-              if (!isInitialized) {
-                  return 'Can\'t send to forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t send to forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  if (event.EventDataType == MessageType.PageEvent) {
-                      reportEvent = true;
-                      logEvent(event);
-                  }
-                  else if (event.EventDataType == MessageType.PageView) {
-                      event.EventName = 'Viewed ' + event.EventName;
-                      reportEvent = true;
-                      logEvent(event);
-                  }
-                  else if (event.EventDataType == MessageType.Commerce &&
-                      event.ProductAction &&
-                      event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
+                try {
+                    if (event.EventDataType == MessageType.PageEvent) {
+                        reportEvent = true;
+                        logEvent(event);
+                    }
+                    else if (event.EventDataType == MessageType.PageView) {
+                        event.EventName = 'Viewed ' + event.EventName;
+                        reportEvent = true;
+                        logEvent(event);
+                    }
+                    else if (event.EventDataType == MessageType.Commerce &&
+                        event.ProductAction &&
+                        event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
-                      reportEvent = true;
-                      logCommerceEvent(event);
-                  }
+                        reportEvent = true;
+                        logCommerceEvent(event);
+                    }
 
-                  if (reportEvent &&
-                      reportingService) {
+                    if (reportEvent &&
+                        reportingService) {
 
-                      reportingService(self, event);
-                  }
+                        reportingService(self, event);
+                    }
 
-                  return 'Successfully sent to forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t send to forwarder: ' + name + ' ' + e;
-              }
-          }
+                    return 'Successfully sent to forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t send to forwarder: ' + name + ' ' + e;
+                }
+            }
 
-          function setUserIdentity(id, type) {
-              if (window.mParticle.getVersion()[0] !== '1') {
-                  return;
-              }
-              if (!id) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
-              }
+            function setUserIdentity(id, type) {
+                if (window.mParticle.getVersion()[0] !== '1') {
+                    return;
+                }
+                if (!id) {
+                    return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
+                }
 
-              if (!isInitialized) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  if (window.mParticle.IdentityType.Alias == type) {
-                      mixpanel.mparticle.alias(id.toString());
-                  }
-                  else {
-                      mixpanel.mparticle.identify(id.toString());
-                  }
+                try {
+                    if (window.mParticle.IdentityType.Alias == type) {
+                        mixpanel.mparticle.alias(id.toString());
+                    }
+                    else {
+                        mixpanel.mparticle.identify(id.toString());
+                    }
 
-                  return 'Successfully called identify on forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully called identify on forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function onUserIdentified(user) {
-              var idForMixpanel;
-              var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
-              switch (forwarderSettings.userIdentificationType) {
-                  case 'CustomerId':
-                      idForMixpanel = userIdentities.customerid;
-                      break;
-                  case 'MPID':
-                      idForMixpanel = user.getMPID();
-                      break;
-                  case 'Other':
-                      idForMixpanel = userIdentities.other;
-                      break;
-                  case 'Other2':
-                      idForMixpanel = userIdentities.other2;
-                      break;
-                  case 'Other3':
-                      idForMixpanel = userIdentities.other3;
-                      break;
-                  case 'Other4':
-                      idForMixpanel = userIdentities.other4;
-                      break;
-                  default:
-                      idForMixpanel = userIdentities.customerid;
-                      break;
-              }
+            function onUserIdentified(user) {
+                var idForMixpanel;
+                var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+                switch (forwarderSettings.userIdentificationType) {
+                    case 'CustomerId':
+                        idForMixpanel = userIdentities.customerid;
+                        break;
+                    case 'MPID':
+                        idForMixpanel = user.getMPID();
+                        break;
+                    case 'Other':
+                        idForMixpanel = userIdentities.other;
+                        break;
+                    case 'Other2':
+                        idForMixpanel = userIdentities.other2;
+                        break;
+                    case 'Other3':
+                        idForMixpanel = userIdentities.other3;
+                        break;
+                    case 'Other4':
+                        idForMixpanel = userIdentities.other4;
+                        break;
+                    default:
+                        idForMixpanel = userIdentities.customerid;
+                        break;
+                }
 
-              if (!isInitialized) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t call identify on forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  mixpanel.mparticle.identify(idForMixpanel);
+                try {
+                    mixpanel.mparticle.identify(idForMixpanel);
 
-                  return 'Successfully called identify on forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully called identify on forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function setUserAttribute(key, value) {
-              var attr = {};
-              attr[key] = value;
+            function setUserAttribute(key, value) {
+                var attr = {};
+                attr[key] = value;
 
-              try {
-                  if (forwarderSettings.useMixpanelPeople) {
-                      mixpanel.mparticle.people.set(attr);
-                  } else {
-                      mixpanel.mparticle.register(attr);
-                  }
-              }
-              catch(e) {
-                  return 'Can\'t call register on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    if (forwarderSettings.useMixpanelPeople) {
+                        mixpanel.mparticle.people.set(attr);
+                    } else {
+                        mixpanel.mparticle.register(attr);
+                    }
+                }
+                catch(e) {
+                    return 'Can\'t call register on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function removeUserAttribute(attribute) {
-              try {
-                  if (forwarderSettings.useMixpanelPeople) {
-                      mixpanel.mparticle.people.unset(attribute);
-                  } else {
-                      mixpanel.mparticle.unregister(attribute);
-                  }
-              }
-              catch(e) {
-                  return 'Can\'t call unregister on forwarder: ' + name + ': ' + e;
-              }
-          }
+            function removeUserAttribute(attribute) {
+                try {
+                    if (forwarderSettings.useMixpanelPeople) {
+                        mixpanel.mparticle.people.unset(attribute);
+                    } else {
+                        mixpanel.mparticle.unregister(attribute);
+                    }
+                }
+                catch(e) {
+                    return 'Can\'t call unregister on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function logEvent(event) {
-              event.EventAttributes = event.EventAttributes || {};
+            function logEvent(event) {
+                event.EventAttributes = event.EventAttributes || {};
 
-              try {
-                  mixpanel.mparticle.track(
-                      event.EventName,
-                      event.EventAttributes);
-              }
-              catch(e) {
-                  return 'Can\'t log event on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    mixpanel.mparticle.track(
+                        event.EventName,
+                        event.EventAttributes);
+                }
+                catch(e) {
+                    return 'Can\'t log event on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function logCommerceEvent(event) {
-              if (!forwarderSettings.useMixpanelPeople) {
-                  return 'Can\'t log commerce event on forwarder: ' + name + ', useMixpanelPeople flag is not set';
-              }
+            function logCommerceEvent(event) {
+                if (!forwarderSettings.useMixpanelPeople) {
+                    return 'Can\'t log commerce event on forwarder: ' + name + ', useMixpanelPeople flag is not set';
+                }
 
-              try {
-                  mixpanel.mparticle.people.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
-              }
-              catch (e) {
-                  return 'Can\'t log commerce event on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    mixpanel.mparticle.people.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
+                }
+                catch (e) {
+                    return 'Can\'t log commerce event on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          this.init = initForwarder;
-          this.process = processEvent;
-          this.setUserAttribute = setUserAttribute;
-          this.setUserIdentity = setUserIdentity;
-          this.onUserIdentified = onUserIdentified;
-          this.removeUserAttribute = removeUserAttribute;
-      };
+            this.init = initForwarder;
+            this.process = processEvent;
+            this.setUserAttribute = setUserAttribute;
+            this.setUserIdentity = setUserIdentity;
+            this.onUserIdentified = onUserIdentified;
+            this.removeUserAttribute = removeUserAttribute;
+        };
 
-      function getId() {
-          return moduleId;
-      }
+        function getId() {
+            return moduleId;
+        }
 
-      function register(config) {
-          if (!config) {
-              window.console.log('You must pass a config object to register the kit ' + name);
-              return;
-          }
+        function register(config) {
+            if (!config) {
+                window.console.log('You must pass a config object to register the kit ' + name);
+                return;
+            }
 
-          if (!isObject(config)) {
-              window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
-              return;
-          }
+            if (!isObject(config)) {
+                window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+                return;
+            }
 
-          if (isObject(config.kits)) {
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          } else {
-              config.kits = {};
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          }
-          window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
-      }
+            if (isObject(config.kits)) {
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            } else {
+                config.kits = {};
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            }
+            window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+        }
 
-      if (window && window.mParticle && window.mParticle.addForwarder) {
-          window.mParticle.addForwarder({
-              name: name,
-              constructor: constructor,
-              getId: getId
-          });
-      }
+        function isObject(val) {
+            return (val != null && typeof val === 'object' && Array.isArray(val) === false);
+        }
 
-      var MixpanelEventForwarder = {
-          register: register
-      };
-  var MixpanelEventForwarder_1 = MixpanelEventForwarder.register;
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
 
-  exports.default = MixpanelEventForwarder;
-  exports.register = MixpanelEventForwarder_1;
+        var MixpanelEventForwarder = {
+            register: register
+        };
+    var MixpanelEventForwarder_1 = MixpanelEventForwarder.register;
 
-  return exports;
+    exports.default = MixpanelEventForwarder;
+    exports.register = MixpanelEventForwarder_1;
+
+    return exports;
 
 }({}));

--- a/dist/MixpanelEventForwarder.common.js
+++ b/dist/MixpanelEventForwarder.common.js
@@ -11,6 +11,16 @@ function isObject(val) {
   return val != null && typeof val === 'object' && Array.isArray(val) === false;
 }
 
+var isobject = /*#__PURE__*/Object.freeze({
+  'default': isObject
+});
+
+function getCjsExportFromNamespace (n) {
+	return n && n['default'] || n;
+}
+
+var isobject$1 = getCjsExportFromNamespace(isobject);
+
 /* eslint-disable no-undef*/
 //  Copyright 2015 mParticle, Inc.
 //
@@ -89,7 +99,7 @@ function isObject(val) {
                 }
                 else if (event.EventDataType == MessageType.Commerce &&
                     event.ProductAction &&
-                    event.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                    event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
                     reportEvent = true;
                     logCommerceEvent(event);
@@ -109,6 +119,9 @@ function isObject(val) {
         }
 
         function setUserIdentity(id, type) {
+            if (window.mParticle.getVersion()[0] !== '1') {
+                return;
+            }
             if (!id) {
                 return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
             }
@@ -124,6 +137,47 @@ function isObject(val) {
                 else {
                     mixpanel.mparticle.identify(id.toString());
                 }
+
+                return 'Successfully called identify on forwarder: ' + name;
+            }
+            catch (e) {
+                return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+            }
+        }
+
+        function onUserIdentified(user) {
+            var idForMixpanel;
+            var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+            switch (forwarderSettings.userIdentificationType) {
+                case 'CustomerId':
+                    idForMixpanel = userIdentities.customerid;
+                    break;
+                case 'MPID':
+                    idForMixpanel = user.getMPID();
+                    break;
+                case 'Other':
+                    idForMixpanel = userIdentities.other;
+                    break;
+                case 'Other2':
+                    idForMixpanel = userIdentities.other2;
+                    break;
+                case 'Other3':
+                    idForMixpanel = userIdentities.other3;
+                    break;
+                case 'Other4':
+                    idForMixpanel = userIdentities.other4;
+                    break;
+                default:
+                    idForMixpanel = userIdentities.customerid;
+                    break;
+            }
+
+            if (!isInitialized) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+            }
+
+            try {
+                mixpanel.mparticle.identify(idForMixpanel);
 
                 return 'Successfully called identify on forwarder: ' + name;
             }
@@ -191,6 +245,7 @@ function isObject(val) {
         this.process = processEvent;
         this.setUserAttribute = setUserAttribute;
         this.setUserIdentity = setUserIdentity;
+        this.onUserIdentified = onUserIdentified;
         this.removeUserAttribute = removeUserAttribute;
     };
 
@@ -204,12 +259,12 @@ function isObject(val) {
             return;
         }
 
-        if (!isObject(config)) {
+        if (!isobject$1(config)) {
             window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
             return;
         }
 
-        if (isObject(config.kits)) {
+        if (isobject$1(config.kits)) {
             config.kits[name] = {
                 constructor: constructor
             };

--- a/dist/MixpanelEventForwarder.common.js
+++ b/dist/MixpanelEventForwarder.common.js
@@ -1,26 +1,5 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
-}
-
-var isobject = /*#__PURE__*/Object.freeze({
-  'default': isObject
-});
-
-function getCjsExportFromNamespace (n) {
-	return n && n['default'] || n;
-}
-
-var isobject$1 = getCjsExportFromNamespace(isobject);
-
 /* eslint-disable no-undef*/
 //  Copyright 2015 mParticle, Inc.
 //
@@ -35,8 +14,6 @@ var isobject$1 = getCjsExportFromNamespace(isobject);
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-    
-
     var name = 'MixpanelEventForwarder',
         moduleId = 10,
         MessageType = {
@@ -173,7 +150,7 @@ var isobject$1 = getCjsExportFromNamespace(isobject);
             }
 
             if (!isInitialized) {
-                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+                return 'Can\'t call identify on forwarder: ' + name + ', not initialized';
             }
 
             try {
@@ -259,12 +236,12 @@ var isobject$1 = getCjsExportFromNamespace(isobject);
             return;
         }
 
-        if (!isobject$1(config)) {
+        if (!isObject(config)) {
             window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
             return;
         }
 
-        if (isobject$1(config.kits)) {
+        if (isObject(config.kits)) {
             config.kits[name] = {
                 constructor: constructor
             };
@@ -275,6 +252,10 @@ var isobject$1 = getCjsExportFromNamespace(isobject);
             };
         }
         window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    function isObject(val) {
+        return (val != null && typeof val === 'object' && Array.isArray(val) === false);
     }
 
     if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/dist/MixpanelEventForwarder.iife.js
+++ b/dist/MixpanelEventForwarder.iife.js
@@ -1,297 +1,278 @@
 var mpMixpanelKit = (function (exports) {
-  /*!
-   * isobject <https://github.com/jonschlinkert/isobject>
-   *
-   * Copyright (c) 2014-2017, Jon Schlinkert.
-   * Released under the MIT License.
-   */
-
-  function isObject(val) {
-    return val != null && typeof val === 'object' && Array.isArray(val) === false;
-  }
-
-  var isobject = /*#__PURE__*/Object.freeze({
-    'default': isObject
-  });
-
-  function getCjsExportFromNamespace (n) {
-  	return n && n['default'] || n;
-  }
-
-  var isobject$1 = getCjsExportFromNamespace(isobject);
-
-  /* eslint-disable no-undef*/
-  //  Copyright 2015 mParticle, Inc.
-  //
-  //  Licensed under the Apache License, Version 2.0 (the "License");
-  //  you may not use this file except in compliance with the License.
-  //  You may obtain a copy of the License at
-  //
-  //      http://www.apache.org/licenses/LICENSE-2.0
-  //
-  //  Unless required by applicable law or agreed to in writing, software
-  //  distributed under the License is distributed on an "AS IS" BASIS,
-  //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  //  See the License for the specific language governing permissions and
-  //  limitations under the License.
-      
-
-      var name = 'MixpanelEventForwarder',
-          moduleId = 10,
-          MessageType = {
-              SessionStart: 1,
-              SessionEnd  : 2,
-              PageView    : 3,
-              PageEvent   : 4,
-              CrashReport : 5,
-              OptOut      : 6,
-              Commerce    : 16
-          };
+    /* eslint-disable no-undef*/
+    //  Copyright 2015 mParticle, Inc.
+    //
+    //  Licensed under the Apache License, Version 2.0 (the "License");
+    //  you may not use this file except in compliance with the License.
+    //  You may obtain a copy of the License at
+    //
+    //      http://www.apache.org/licenses/LICENSE-2.0
+    //
+    //  Unless required by applicable law or agreed to in writing, software
+    //  distributed under the License is distributed on an "AS IS" BASIS,
+    //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    //  See the License for the specific language governing permissions and
+    //  limitations under the License.
+        var name = 'MixpanelEventForwarder',
+            moduleId = 10,
+            MessageType = {
+                SessionStart: 1,
+                SessionEnd  : 2,
+                PageView    : 3,
+                PageEvent   : 4,
+                CrashReport : 5,
+                OptOut      : 6,
+                Commerce    : 16
+            };
 
 
-      var constructor = function () {
-          var self = this,
-              isInitialized = false,
-              forwarderSettings = null,
-              reportingService = null;
+        var constructor = function () {
+            var self = this,
+                isInitialized = false,
+                forwarderSettings = null,
+                reportingService = null;
 
-          self.name = name;
+            self.name = name;
 
-          function initForwarder(settings, service, testMode) {
-              forwarderSettings = settings;
-              reportingService = service;
+            function initForwarder(settings, service, testMode) {
+                forwarderSettings = settings;
+                reportingService = service;
 
-              try {
-                  if (!testMode) {
-                      /* eslint-disable */
-                      (function(e,b){if (!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)));};}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
-                      for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d]);};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);}})(document,window.mixpanel||[]);
-                      /* eslint-enable */
-                      mixpanel.init(settings.token, {}, 'mparticle');
-                  }
+                try {
+                    if (!testMode) {
+                        /* eslint-disable */
+                        (function(e,b){if (!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)));};}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
+                        for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d]);};b.__SV=1.2;a=e.createElement("script");a.type="text/javascript";a.async=!0;a.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";f=e.getElementsByTagName("script")[0];f.parentNode.insertBefore(a,f);}})(document,window.mixpanel||[]);
+                        /* eslint-enable */
+                        mixpanel.init(settings.token, {}, 'mparticle');
+                    }
 
-                  isInitialized = true;
+                    isInitialized = true;
 
-                  return 'Successfully initialized: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t initialize forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully initialized: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t initialize forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function processEvent(event) {
-              var reportEvent = false;
+            function processEvent(event) {
+                var reportEvent = false;
 
-              if (!isInitialized) {
-                  return 'Can\'t send to forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t send to forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  if (event.EventDataType == MessageType.PageEvent) {
-                      reportEvent = true;
-                      logEvent(event);
-                  }
-                  else if (event.EventDataType == MessageType.PageView) {
-                      event.EventName = 'Viewed ' + event.EventName;
-                      reportEvent = true;
-                      logEvent(event);
-                  }
-                  else if (event.EventDataType == MessageType.Commerce &&
-                      event.ProductAction &&
-                      event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
+                try {
+                    if (event.EventDataType == MessageType.PageEvent) {
+                        reportEvent = true;
+                        logEvent(event);
+                    }
+                    else if (event.EventDataType == MessageType.PageView) {
+                        event.EventName = 'Viewed ' + event.EventName;
+                        reportEvent = true;
+                        logEvent(event);
+                    }
+                    else if (event.EventDataType == MessageType.Commerce &&
+                        event.ProductAction &&
+                        event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
-                      reportEvent = true;
-                      logCommerceEvent(event);
-                  }
+                        reportEvent = true;
+                        logCommerceEvent(event);
+                    }
 
-                  if (reportEvent &&
-                      reportingService) {
+                    if (reportEvent &&
+                        reportingService) {
 
-                      reportingService(self, event);
-                  }
+                        reportingService(self, event);
+                    }
 
-                  return 'Successfully sent to forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t send to forwarder: ' + name + ' ' + e;
-              }
-          }
+                    return 'Successfully sent to forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t send to forwarder: ' + name + ' ' + e;
+                }
+            }
 
-          function setUserIdentity(id, type) {
-              if (window.mParticle.getVersion()[0] !== '1') {
-                  return;
-              }
-              if (!id) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
-              }
+            function setUserIdentity(id, type) {
+                if (window.mParticle.getVersion()[0] !== '1') {
+                    return;
+                }
+                if (!id) {
+                    return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
+                }
 
-              if (!isInitialized) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  if (window.mParticle.IdentityType.Alias == type) {
-                      mixpanel.mparticle.alias(id.toString());
-                  }
-                  else {
-                      mixpanel.mparticle.identify(id.toString());
-                  }
+                try {
+                    if (window.mParticle.IdentityType.Alias == type) {
+                        mixpanel.mparticle.alias(id.toString());
+                    }
+                    else {
+                        mixpanel.mparticle.identify(id.toString());
+                    }
 
-                  return 'Successfully called identify on forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully called identify on forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function onUserIdentified(user) {
-              var idForMixpanel;
-              var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
-              switch (forwarderSettings.userIdentificationType) {
-                  case 'CustomerId':
-                      idForMixpanel = userIdentities.customerid;
-                      break;
-                  case 'MPID':
-                      idForMixpanel = user.getMPID();
-                      break;
-                  case 'Other':
-                      idForMixpanel = userIdentities.other;
-                      break;
-                  case 'Other2':
-                      idForMixpanel = userIdentities.other2;
-                      break;
-                  case 'Other3':
-                      idForMixpanel = userIdentities.other3;
-                      break;
-                  case 'Other4':
-                      idForMixpanel = userIdentities.other4;
-                      break;
-                  default:
-                      idForMixpanel = userIdentities.customerid;
-                      break;
-              }
+            function onUserIdentified(user) {
+                var idForMixpanel;
+                var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+                switch (forwarderSettings.userIdentificationType) {
+                    case 'CustomerId':
+                        idForMixpanel = userIdentities.customerid;
+                        break;
+                    case 'MPID':
+                        idForMixpanel = user.getMPID();
+                        break;
+                    case 'Other':
+                        idForMixpanel = userIdentities.other;
+                        break;
+                    case 'Other2':
+                        idForMixpanel = userIdentities.other2;
+                        break;
+                    case 'Other3':
+                        idForMixpanel = userIdentities.other3;
+                        break;
+                    case 'Other4':
+                        idForMixpanel = userIdentities.other4;
+                        break;
+                    default:
+                        idForMixpanel = userIdentities.customerid;
+                        break;
+                }
 
-              if (!isInitialized) {
-                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
-              }
+                if (!isInitialized) {
+                    return 'Can\'t call identify on forwarder: ' + name + ', not initialized';
+                }
 
-              try {
-                  mixpanel.mparticle.identify(idForMixpanel);
+                try {
+                    mixpanel.mparticle.identify(idForMixpanel);
 
-                  return 'Successfully called identify on forwarder: ' + name;
-              }
-              catch (e) {
-                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
-              }
-          }
+                    return 'Successfully called identify on forwarder: ' + name;
+                }
+                catch (e) {
+                    return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function setUserAttribute(key, value) {
-              var attr = {};
-              attr[key] = value;
+            function setUserAttribute(key, value) {
+                var attr = {};
+                attr[key] = value;
 
-              try {
-                  if (forwarderSettings.useMixpanelPeople) {
-                      mixpanel.mparticle.people.set(attr);
-                  } else {
-                      mixpanel.mparticle.register(attr);
-                  }
-              }
-              catch(e) {
-                  return 'Can\'t call register on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    if (forwarderSettings.useMixpanelPeople) {
+                        mixpanel.mparticle.people.set(attr);
+                    } else {
+                        mixpanel.mparticle.register(attr);
+                    }
+                }
+                catch(e) {
+                    return 'Can\'t call register on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function removeUserAttribute(attribute) {
-              try {
-                  if (forwarderSettings.useMixpanelPeople) {
-                      mixpanel.mparticle.people.unset(attribute);
-                  } else {
-                      mixpanel.mparticle.unregister(attribute);
-                  }
-              }
-              catch(e) {
-                  return 'Can\'t call unregister on forwarder: ' + name + ': ' + e;
-              }
-          }
+            function removeUserAttribute(attribute) {
+                try {
+                    if (forwarderSettings.useMixpanelPeople) {
+                        mixpanel.mparticle.people.unset(attribute);
+                    } else {
+                        mixpanel.mparticle.unregister(attribute);
+                    }
+                }
+                catch(e) {
+                    return 'Can\'t call unregister on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function logEvent(event) {
-              event.EventAttributes = event.EventAttributes || {};
+            function logEvent(event) {
+                event.EventAttributes = event.EventAttributes || {};
 
-              try {
-                  mixpanel.mparticle.track(
-                      event.EventName,
-                      event.EventAttributes);
-              }
-              catch(e) {
-                  return 'Can\'t log event on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    mixpanel.mparticle.track(
+                        event.EventName,
+                        event.EventAttributes);
+                }
+                catch(e) {
+                    return 'Can\'t log event on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          function logCommerceEvent(event) {
-              if (!forwarderSettings.useMixpanelPeople) {
-                  return 'Can\'t log commerce event on forwarder: ' + name + ', useMixpanelPeople flag is not set';
-              }
+            function logCommerceEvent(event) {
+                if (!forwarderSettings.useMixpanelPeople) {
+                    return 'Can\'t log commerce event on forwarder: ' + name + ', useMixpanelPeople flag is not set';
+                }
 
-              try {
-                  mixpanel.mparticle.people.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
-              }
-              catch (e) {
-                  return 'Can\'t log commerce event on forwarder: ' + name + ': ' + e;
-              }
-          }
+                try {
+                    mixpanel.mparticle.people.track_charge(event.ProductAction.TotalAmount, {'$time': new Date().toISOString()});
+                }
+                catch (e) {
+                    return 'Can\'t log commerce event on forwarder: ' + name + ': ' + e;
+                }
+            }
 
-          this.init = initForwarder;
-          this.process = processEvent;
-          this.setUserAttribute = setUserAttribute;
-          this.setUserIdentity = setUserIdentity;
-          this.onUserIdentified = onUserIdentified;
-          this.removeUserAttribute = removeUserAttribute;
-      };
+            this.init = initForwarder;
+            this.process = processEvent;
+            this.setUserAttribute = setUserAttribute;
+            this.setUserIdentity = setUserIdentity;
+            this.onUserIdentified = onUserIdentified;
+            this.removeUserAttribute = removeUserAttribute;
+        };
 
-      function getId() {
-          return moduleId;
-      }
+        function getId() {
+            return moduleId;
+        }
 
-      function register(config) {
-          if (!config) {
-              window.console.log('You must pass a config object to register the kit ' + name);
-              return;
-          }
+        function register(config) {
+            if (!config) {
+                window.console.log('You must pass a config object to register the kit ' + name);
+                return;
+            }
 
-          if (!isobject$1(config)) {
-              window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
-              return;
-          }
+            if (!isObject(config)) {
+                window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+                return;
+            }
 
-          if (isobject$1(config.kits)) {
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          } else {
-              config.kits = {};
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          }
-          window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
-      }
+            if (isObject(config.kits)) {
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            } else {
+                config.kits = {};
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            }
+            window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+        }
 
-      if (window && window.mParticle && window.mParticle.addForwarder) {
-          window.mParticle.addForwarder({
-              name: name,
-              constructor: constructor,
-              getId: getId
-          });
-      }
+        function isObject(val) {
+            return (val != null && typeof val === 'object' && Array.isArray(val) === false);
+        }
 
-      var MixpanelEventForwarder = {
-          register: register
-      };
-  var MixpanelEventForwarder_1 = MixpanelEventForwarder.register;
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
 
-  exports.default = MixpanelEventForwarder;
-  exports.register = MixpanelEventForwarder_1;
+        var MixpanelEventForwarder = {
+            register: register
+        };
+    var MixpanelEventForwarder_1 = MixpanelEventForwarder.register;
 
-  return exports;
+    exports.default = MixpanelEventForwarder;
+    exports.register = MixpanelEventForwarder_1;
+
+    return exports;
 
 }({}));

--- a/dist/MixpanelEventForwarder.iife.js
+++ b/dist/MixpanelEventForwarder.iife.js
@@ -10,6 +10,16 @@ var mpMixpanelKit = (function (exports) {
     return val != null && typeof val === 'object' && Array.isArray(val) === false;
   }
 
+  var isobject = /*#__PURE__*/Object.freeze({
+    'default': isObject
+  });
+
+  function getCjsExportFromNamespace (n) {
+  	return n && n['default'] || n;
+  }
+
+  var isobject$1 = getCjsExportFromNamespace(isobject);
+
   /* eslint-disable no-undef*/
   //  Copyright 2015 mParticle, Inc.
   //
@@ -88,7 +98,7 @@ var mpMixpanelKit = (function (exports) {
                   }
                   else if (event.EventDataType == MessageType.Commerce &&
                       event.ProductAction &&
-                      event.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                      event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
                       reportEvent = true;
                       logCommerceEvent(event);
@@ -108,6 +118,9 @@ var mpMixpanelKit = (function (exports) {
           }
 
           function setUserIdentity(id, type) {
+              if (window.mParticle.getVersion()[0] !== '1') {
+                  return;
+              }
               if (!id) {
                   return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
               }
@@ -123,6 +136,47 @@ var mpMixpanelKit = (function (exports) {
                   else {
                       mixpanel.mparticle.identify(id.toString());
                   }
+
+                  return 'Successfully called identify on forwarder: ' + name;
+              }
+              catch (e) {
+                  return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+              }
+          }
+
+          function onUserIdentified(user) {
+              var idForMixpanel;
+              var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+              switch (forwarderSettings.userIdentificationType) {
+                  case 'CustomerId':
+                      idForMixpanel = userIdentities.customerid;
+                      break;
+                  case 'MPID':
+                      idForMixpanel = user.getMPID();
+                      break;
+                  case 'Other':
+                      idForMixpanel = userIdentities.other;
+                      break;
+                  case 'Other2':
+                      idForMixpanel = userIdentities.other2;
+                      break;
+                  case 'Other3':
+                      idForMixpanel = userIdentities.other3;
+                      break;
+                  case 'Other4':
+                      idForMixpanel = userIdentities.other4;
+                      break;
+                  default:
+                      idForMixpanel = userIdentities.customerid;
+                      break;
+              }
+
+              if (!isInitialized) {
+                  return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+              }
+
+              try {
+                  mixpanel.mparticle.identify(idForMixpanel);
 
                   return 'Successfully called identify on forwarder: ' + name;
               }
@@ -190,6 +244,7 @@ var mpMixpanelKit = (function (exports) {
           this.process = processEvent;
           this.setUserAttribute = setUserAttribute;
           this.setUserIdentity = setUserIdentity;
+          this.onUserIdentified = onUserIdentified;
           this.removeUserAttribute = removeUserAttribute;
       };
 
@@ -203,12 +258,12 @@ var mpMixpanelKit = (function (exports) {
               return;
           }
 
-          if (!isObject(config)) {
+          if (!isobject$1(config)) {
               window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
               return;
           }
 
-          if (isObject(config.kits)) {
+          if (isobject$1(config.kits)) {
               config.kits[name] = {
                   constructor: constructor
               };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,25 @@
 {
   "name": "@mparticle/web-mixpanel-kit",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@mparticle/web-sdk": {
-      "version": "2.9.4-rc.3",
-      "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.9.4-rc.3.tgz",
-      "integrity": "sha512-vBKgswE13U1BUuOgH6J9LH0+yrzJbQ0d87HHHGU3aZ2xFJXvxybFjqCrl7utfYsNF8vALSpysI8BrtSjGZ/Ixw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.11.8.tgz",
+      "integrity": "sha512-foZHluj9+IRQNCLuYBYG15mexlARAj+GsOWp9WhjQJki2oMdHLmGp+6knNbHwvPMJwo3yy8UkNKIJ7yAEf9rVQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.0",
+        "slugify": "^1.3.6"
+      }
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -172,11 +184,6 @@
         "@types/estree": "0.0.39"
       }
     },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-    },
     "magic-string": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
@@ -255,6 +262,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "resolve": {
       "version": "1.11.1",
@@ -364,6 +376,11 @@
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
+    },
+    "slugify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
+      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "sourcemap-codec": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-mixpanel-kit",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Mixpanel",
   "browser": "dist/MixpanelEventForwarder.common.js",
@@ -21,8 +21,7 @@
     "rollup-plugin-node-resolve": "^5.0.1"
   },
   "dependencies": {
-    "isobject": "^4.0.0",
-    "@mparticle/web-sdk": "^2.9.4-rc.1"
+    "@mparticle/web-sdk": "^2.11.8"
   },
   "license": "Apache-2.0"
 }

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -78,7 +78,7 @@
                 }
                 else if (event.EventDataType == MessageType.Commerce &&
                     event.ProductAction &&
-                    event.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                    event.ProductAction.ProductActionType == window.mParticle.ProductActionType.Purchase) {
 
                     reportEvent = true;
                     logCommerceEvent(event);
@@ -98,6 +98,9 @@
         }
 
         function setUserIdentity(id, type) {
+            if (window.mParticle.getVersion()[0] !== '1') {
+                return;
+            }
             if (!id) {
                 return 'Can\'t call setUserIdentity on forwarder: ' + name + ' without ID';
             }
@@ -113,6 +116,47 @@
                 else {
                     mixpanel.mparticle.identify(id.toString());
                 }
+
+                return 'Successfully called identify on forwarder: ' + name;
+            }
+            catch (e) {
+                return 'Can\'t call identify on forwarder: ' + name + ': ' + e;
+            }
+        }
+
+        function onUserIdentified(user) {
+            var idForMixpanel;
+            var userIdentities = user.getUserIdentities() ? user.getUserIdentities().userIdentities : {};
+            switch (forwarderSettings.userIdentificationType) {
+                case 'CustomerId':
+                    idForMixpanel = userIdentities.customerid;
+                    break;
+                case 'MPID':
+                    idForMixpanel = user.getMPID();
+                    break;
+                case 'Other':
+                    idForMixpanel = userIdentities.other;
+                    break;
+                case 'Other2':
+                    idForMixpanel = userIdentities.other2;
+                    break;
+                case 'Other3':
+                    idForMixpanel = userIdentities.other3;
+                    break;
+                case 'Other4':
+                    idForMixpanel = userIdentities.other4;
+                    break;
+                default:
+                    idForMixpanel = userIdentities.customerid;
+                    break;
+            }
+
+            if (!isInitialized) {
+                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+            }
+
+            try {
+                mixpanel.mparticle.identify(idForMixpanel);
 
                 return 'Successfully called identify on forwarder: ' + name;
             }
@@ -180,6 +224,7 @@
         this.process = processEvent;
         this.setUserAttribute = setUserAttribute;
         this.setUserIdentity = setUserIdentity;
+        this.onUserIdentified = onUserIdentified;
         this.removeUserAttribute = removeUserAttribute;
     };
 

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -12,8 +12,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-    var isobject = require('isobject');
-
     var name = 'MixpanelEventForwarder',
         moduleId = 10,
         MessageType = {
@@ -152,7 +150,7 @@
             }
 
             if (!isInitialized) {
-                return 'Can\'t call setUserIdentity on forwarder: ' + name + ', not initialized';
+                return 'Can\'t call identify on forwarder: ' + name + ', not initialized';
             }
 
             try {
@@ -238,12 +236,12 @@
             return;
         }
 
-        if (!isobject(config)) {
+        if (!isObject(config)) {
             window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
             return;
         }
 
-        if (isobject(config.kits)) {
+        if (isObject(config.kits)) {
             config.kits[name] = {
                 constructor: constructor
             };
@@ -254,6 +252,10 @@
             };
         }
         window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+    }
+
+    function isObject(val) {
+        return (val != null && typeof val === 'object' && Array.isArray(val) === false);
     }
 
     if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -193,10 +193,84 @@ describe('Mixpanel Forwarder', function () {
             done();
         });
 
-        it('should identify user', function(done) {
+        it('should identify user (mParticle SDK v1)', function(done) {
             mParticle.forwarder.setUserIdentity('dpatel@mparticle.com', mParticle.IdentityType.CustomerId);
             window.mixpanel.mparticle.should.have.property('identifyCalled', true);
             window.mixpanel.mparticle.should.have.property('data', 'dpatel@mparticle.com');
+
+            done();
+        });
+
+        it('should identify user (mParticle SDK v2)', function(done) {
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'CustomerId'
+            }, reportService.cb, true);
+            var user = {
+                getUserIdentities: function() {
+                    return {
+                        userIdentities: {
+                            customerid: 'cust1',
+                            other: 'other1',
+                            other2: 'other2',
+                            other3: 'other3',
+                            other4: 'other4'
+                        }
+                    };
+                },
+                getMPID: function() {
+                    return 'mpid1';
+                },
+            };
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'cust1');
+
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'MPID'
+            }, reportService.cb, true);
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'mpid1');
+
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'Other'
+            }, reportService.cb, true);
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'other1');
+
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'Other2'
+            }, reportService.cb, true);
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'other2');
+
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'Other3'
+            }, reportService.cb, true);
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'other3');
+
+            mParticle.forwarder.init({
+                includeUserAttributes: 'True',
+                userIdentificationType: 'Other4'
+            }, reportService.cb, true);
+
+            mParticle.forwarder.onUserIdentified(user);
+            window.mixpanel.mparticle.should.have.property('identifyCalled', true);
+            window.mixpanel.mparticle.should.have.property('data', 'other4');
 
             done();
         });


### PR DESCRIPTION
Note: focus just on `src/MixpanelEventForwarder.js` as the other files are simply built.

It appears that `onUserIdentified` was never implemented on the Mixpanel Kit. Our [docs](https://docs.mparticle.com/integrations/mixpanel/event/#option-1---use-mparticle-id-as-the-distinct-id) state that the External Identity Type will set the identity type that we pass to Mixpanel, and before this PR, this does not work on Web. 

`setUserIdentity` should only be called for our JS SDK v1, so I updated the code to return if it's not on SDK v2. Otherwise, we loop through all user identities and call this function multiple times.