### PR TITLE
[WIP] Add support for commerce events other than purchase

### DIFF
--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -84,8 +84,10 @@ var constructor = function() {
             } else if (
                 event.EventDataType == MessageType.Commerce &&
                 event.ProductAction &&
+                (event.ProductAction.ProductActionType ==
+                    window.mParticle.ProductActionType.Purchase ||
                 event.ProductAction.ProductActionType ==
-                    window.mParticle.ProductActionType.Purchase
+                    window.mParticle.ProductActionType.Refund)
             ) {
                 reportEvent = true;
                 logCommerceEvent(event);
@@ -225,10 +227,16 @@ var constructor = function() {
                 ', useMixpanelPeople flag is not set'
             );
         }
-
+        
+        var totalAmount = event.ProductAction.TotalAmount;
+        if (event.ProductAction.ProductActionType
+            == window.mParticle.ProductActionType.Refund) {
+            totalAmount = -Math.abs(totalAmount);
+        }
+        
         try {
             mixpanel.mparticle.people.track_charge(
-                event.ProductAction.TotalAmount,
+                totalAmount,
                 { $time: new Date().toISOString() }
             );
         } catch (e) {


### PR DESCRIPTION
## Summary
- Add support for commerce events other than purchase
- Refund event will always call Mixpanel's track_charge with a negative amount
- Events other than purchase or refund will be mapped to regular Mixpanel events, similar to what S2S forwarder does

## Testing Plan
- TBD

## Reference Issue
- [ZD9225](https://mparticlehelp.zendesk.com/agent/tickets/9225)
- [Reddit](https://www.reddit.com/r/mparticle/comments/x7kk90/ecommerce_events_not_being_forwarded_to_mixpanel/)
