### PR TITLE
fix: Split out logout function from onUserIdentified

### DIFF
--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -16,7 +16,7 @@
 // ** Glossary of terms
 // Mixpanel Terms:
 // user_id: A unique identifier used by the Mixpanel.identify method to identify a unique user.  This will map to what an mParticle customer selects in the UI, which translates to the forwarderSettings.userIdentificationType.
-// device_id: A unique identifier used by Mixpanel to identify an anonymous user, usually a guid
+// device_id: A unique identifier used by Mixpanel to identify an anonymous user, usually a guid.  mParticle and Mixpnael generate their own device ids.
 // distinct_id: A unique identifier that Mixpanel uses to bridge a user and a device. Usually the
 //              distinct_id has a prefix of $device:guid<device_id> to denote an anonymouse user
 //              and this will be replaced by the user_id once the user has been identified by
@@ -189,31 +189,33 @@ var constructor = function () {
     }
 
     function onIdentifyComplete(user) {
-        // When mParticle identifies a user, the user might
-        // actually be anonymous. We only want to send an
+        // Mixpanel considers any user with an identity to be a known user.
+        // In mParticle, a user will always have an MPID even if they are anonymous.
+        // When mParticle identifies a user, because the user might
+        // actually be anonymous, we only want to send an
         // identify request to Mixpanel if the user is
-        // actually known. Only known (logged in) users
-        // will have userIdentities.
+        // actually known. If a user has any user identities, they are 
+        // considered to be "known" users.
         var userIdentities = getUserIdentities(user);
 
         if (!isEmpty(userIdentities)) {
             sendIdentifyRequest(user, userIdentities);
         } else {
-            return 'User is anonymous';
+            return 'Modified user does not have user identities and will not be sent to Mixpanel to Identify';
         }
     }
 
     function onModifyComplete(user) {
         // Mixpanel does not have the concept of modifying a
         // user's identity. For the time being, we will rely on
-        // doing a simple Mixpanel.identify request. However
+        // doing a simple Mixpanel.identify request for backwards compatibility. However
         // this method may be deprecated in a future release
         var userIdentities = getUserIdentities(user);
 
         if (!isEmpty(userIdentities)) {
             sendIdentifyRequest(user, userIdentities);
         } else {
-            return 'User is anonymous';
+            return 'Modified user does not have user identities and will not be sent to Mixpanel to Identify';
         }
     }
 

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -13,6 +13,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// ** Glossary of terms
+// Mixpanel Terms:
+// user_id: A unique identifier used by the Mixpanel.identify method to identify a unique user
+// device_id: A unique identifier used by Mixpanel to identify an anonymous user, usually a guid
+// distinct_id: A unique identifier that Mixpanel uses to bridge a user and a device. Usually the
+//              distinct_id has a prefix of $device:guid<device_id> to denote an anonymouse user
+//              and this will be replaced by the user_id once the user has been identified by
+//              a request to Mixpanel.identify
+
 // eslint-disable-next-line no-redeclare
 var name = 'MixpanelEventForwarder',
     moduleId = 10,
@@ -288,15 +297,15 @@ var constructor = function () {
 
     this.onLoginComplete = onLoginComplete;
 
-    // For all Identity Requests, we run mixpanel.identify(<device_id)
+    // For all Identity Requests, we run mixpanel.identify(<user_id>)
     // as per Mixpanel's documentation https://docs.mixpanel.com/docs/tracking-methods/identifying-users
     // except when a user logs out, where we run mixpanel.reset() to
-    // detach the distinct_id from the device_id
+    // detach the Mixpanel distinct_id from the Mixpanel device_id
     this.onLogoutComplete = onLogoutComplete;
 
     // For these two methods, we are essentially passing along the
     // Identify request the same way.
-    this.onIdentifyComplte = sendIdentifyRequest;
+    this.onIdentifyComplete = sendIdentifyRequest;
     this.onModifyComplete = sendIdentifyRequest;
 };
 

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -137,6 +137,24 @@ var constructor = function () {
         }
     }
 
+    function onLogoutComplete() {
+        if (!isInitialized) {
+            return (
+                'Cannot call logout on forwarder: ' +
+                name +
+                ', not initialized'
+            );
+        }
+
+        try {
+            mixpanel.mparticle.reset();
+
+            return 'Successfully called reset on forwarder: ' + name;
+        } catch (e) {
+            return 'Cannot call reset on forwarder: ' + name + ': ' + e;
+        }
+    }
+
     function onUserIdentified(user) {
         var idForMixpanel;
         var userIdentities = user.getUserIdentities()
@@ -245,8 +263,17 @@ var constructor = function () {
     this.process = processEvent;
     this.setUserAttribute = setUserAttribute;
     this.setUserIdentity = setUserIdentity;
-    this.onUserIdentified = onUserIdentified;
     this.removeUserAttribute = removeUserAttribute;
+    
+    // For all Identity Requests, we run mixpanel.identify(<device_id)
+    // as per Mixpanel's documentation https://docs.mixpanel.com/docs/tracking-methods/identifying-users
+    // except when a user logs out, where we run mixpanel.reset() to
+    // detach the distinct_id from the device_id
+    this.onLogoutComplete = onLogoutComplete;
+
+    this.onLoginComplete = onUserIdentified;
+    this.onIdentifyComplte = onUserIdentified;
+    this.onModifyComplete = onUserIdentified;
 };
 
 function getId() {

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -201,7 +201,7 @@ var constructor = function () {
         if (!isEmpty(userIdentities)) {
             sendIdentifyRequest(user, userIdentities);
         } else {
-            return 'Modified user does not have user identities and will not be sent to Mixpanel to Identify';
+            return 'Identified user does not have user identities and will not be sent to Mixpanel to Identify';
         }
     }
 

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -15,7 +15,7 @@
 
 // ** Glossary of terms
 // Mixpanel Terms:
-// user_id: A unique identifier used by the Mixpanel.identify method to identify a unique user
+// user_id: A unique identifier used by the Mixpanel.identify method to identify a unique user.  This will map to what an mParticle customer selects in the UI, which translates to the forwarderSettings.userIdentificationType.
 // device_id: A unique identifier used by Mixpanel to identify an anonymous user, usually a guid
 // distinct_id: A unique identifier that Mixpanel uses to bridge a user and a device. Usually the
 //              distinct_id has a prefix of $device:guid<device_id> to denote an anonymouse user

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -419,7 +419,7 @@ describe('Mixpanel Forwarder', function () {
                     true
                 );
 
-                mParticle.forwarder.onIdentifyComplte(user);
+                mParticle.forwarder.onIdentifyComplete(user);
                 window.mixpanel.mparticle.should.have.property(
                     'identifyCalled',
                     true

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -104,6 +104,10 @@ describe('Mixpanel Forwarder', function () {
             setCalledAttributes(data, 'identifyCalled');
         };
 
+        this.mparticle.reset = function (data) {
+            setCalledAttributes(data, 'resetCalled');
+        };
+
         this.mparticle.alias = function (data) {
             setCalledAttributes(data, 'aliasCalled');
         };
@@ -284,15 +288,8 @@ describe('Mixpanel Forwarder', function () {
             done();
         });
 
-        it('should identify user (mParticle SDK v2)', function (done) {
-            mParticle.forwarder.init(
-                {
-                    includeUserAttributes: 'True',
-                    userIdentificationType: 'CustomerId',
-                },
-                reportService.cb,
-                true
-            );
+        it('should log in a user (mParticle SDK v2)', function (done) {
+
             var user = {
                 getUserIdentities: function () {
                     return {
@@ -310,92 +307,195 @@ describe('Mixpanel Forwarder', function () {
                 },
             };
 
-            mParticle.forwarder.onUserIdentified(user);
-            window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
-                true
-            );
-            window.mixpanel.mparticle.should.have.property('data', 'cust1');
-
-            mParticle.forwarder.init(
+            var identificationTypes = [
                 {
-                    includeUserAttributes: 'True',
-                    userIdentificationType: 'MPID',
+                    userIdentificationType: 'CustomerId',
+                    expectedProperty: 'cust1'
                 },
-                reportService.cb,
-                true
-            );
-
-            mParticle.forwarder.onUserIdentified(user);
-            window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
-                true
-            );
-            window.mixpanel.mparticle.should.have.property('data', 'mpid1');
-
-            mParticle.forwarder.init(
                 {
-                    includeUserAttributes: 'True',
                     userIdentificationType: 'Other',
+                    expectedProperty: 'other1'
                 },
-                reportService.cb,
-                true
-            );
-
-            mParticle.forwarder.onUserIdentified(user);
-            window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
-                true
-            );
-            window.mixpanel.mparticle.should.have.property('data', 'other1');
-
-            mParticle.forwarder.init(
                 {
-                    includeUserAttributes: 'True',
                     userIdentificationType: 'Other2',
+                    expectedProperty: 'other2'
                 },
-                reportService.cb,
-                true
-            );
-
-            mParticle.forwarder.onUserIdentified(user);
-            window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
-                true
-            );
-            window.mixpanel.mparticle.should.have.property('data', 'other2');
-
-            mParticle.forwarder.init(
                 {
-                    includeUserAttributes: 'True',
                     userIdentificationType: 'Other3',
+                    expectedProperty: 'other3'
                 },
-                reportService.cb,
-                true
-            );
+                {
+                    userIdentificationType: 'Other4',
+                    expectedProperty: 'other4'
+                },
+            ];
 
-            mParticle.forwarder.onUserIdentified(user);
-            window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
-                true
-            );
-            window.mixpanel.mparticle.should.have.property('data', 'other3');
+            identificationTypes.forEach(function (identificationType) {
+                mParticle.forwarder.init(
+                    {
+                        includeUserAttributes: 'True',
+                        userIdentificationType: identificationType.userIdentificationType
+                    },
+                    reportService.cb,
+                    true
+                );
+    
+                mParticle.forwarder.onLoginComplete(user);
+                window.mixpanel.mparticle.should.have.property(
+                    'identifyCalled',
+                    true
+                );
+                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
+
+            });
+
+            done();
+        });
+
+        it('should identify a user (mParticle SDK v2)', function (done) {
+
+            var user = {
+                getUserIdentities: function () {
+                    return {
+                        userIdentities: {
+                            customerid: 'cust1',
+                            other: 'other1',
+                            other2: 'other2',
+                            other3: 'other3',
+                            other4: 'other4',
+                        },
+                    };
+                },
+                getMPID: function () {
+                    return 'mpid1';
+                },
+            };
+
+            var identificationTypes = [
+                {
+                    userIdentificationType: 'CustomerId',
+                    expectedProperty: 'cust1'
+                },
+                {
+                    userIdentificationType: 'Other',
+                    expectedProperty: 'other1'
+                },
+                {
+                    userIdentificationType: 'Other2',
+                    expectedProperty: 'other2'
+                },
+                {
+                    userIdentificationType: 'Other3',
+                    expectedProperty: 'other3'
+                },
+                {
+                    userIdentificationType: 'Other4',
+                    expectedProperty: 'other4'
+                },
+            ];
+
+            identificationTypes.forEach(function (identificationType) {
+                mParticle.forwarder.init(
+                    {
+                        includeUserAttributes: 'True',
+                        userIdentificationType: identificationType.userIdentificationType
+                    },
+                    reportService.cb,
+                    true
+                );
+    
+                mParticle.forwarder.onIdentifyComplte(user);
+                window.mixpanel.mparticle.should.have.property(
+                    'identifyCalled',
+                    true
+                );
+                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
+
+            });
+
+            done();
+        });
+
+        it('should modify a user\'s identity (mParticle SDK v2)', function (done) {
+
+            var user = {
+                getUserIdentities: function () {
+                    return {
+                        userIdentities: {
+                            customerid: 'cust1',
+                            other: 'other1',
+                            other2: 'other2',
+                            other3: 'other3',
+                            other4: 'other4',
+                        },
+                    };
+                },
+                getMPID: function () {
+                    return 'mpid1';
+                },
+            };
+
+            var identificationTypes = [
+                {
+                    userIdentificationType: 'CustomerId',
+                    expectedProperty: 'cust1'
+                },
+                {
+                    userIdentificationType: 'Other',
+                    expectedProperty: 'other1'
+                },
+                {
+                    userIdentificationType: 'Other2',
+                    expectedProperty: 'other2'
+                },
+                {
+                    userIdentificationType: 'Other3',
+                    expectedProperty: 'other3'
+                },
+                {
+                    userIdentificationType: 'Other4',
+                    expectedProperty: 'other4'
+                },
+            ];
+
+            identificationTypes.forEach(function (identificationType) {
+                mParticle.forwarder.init(
+                    {
+                        includeUserAttributes: 'True',
+                        userIdentificationType: identificationType.userIdentificationType
+                    },
+                    reportService.cb,
+                    true
+                );
+    
+                mParticle.forwarder.onModifyComplete(user);
+                window.mixpanel.mparticle.should.have.property(
+                    'identifyCalled',
+                    true
+                );
+                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
+
+            });
+
+            done();
+        });
+
+        it('should log out a user (mParticle SDK v2)', function (done) {
 
             mParticle.forwarder.init(
                 {
                     includeUserAttributes: 'True',
-                    userIdentificationType: 'Other4',
+                    userIdentificationType: 'MPID'
                 },
                 reportService.cb,
                 true
             );
 
-            mParticle.forwarder.onUserIdentified(user);
+            mParticle.forwarder.onLogoutComplete();
             window.mixpanel.mparticle.should.have.property(
-                'identifyCalled',
+                'resetCalled',
                 true
             );
-            window.mixpanel.mparticle.should.have.property('data', 'other4');
 
             done();
         });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -104,8 +104,8 @@ describe('Mixpanel Forwarder', function () {
             setCalledAttributes(data, 'identifyCalled');
         };
 
-        this.mparticle.reset = function (data) {
-            setCalledAttributes(data, 'resetCalled');
+        this.mparticle.reset = function () {
+            setCalledAttributes(null, 'resetCalled');
         };
 
         this.mparticle.alias = function (data) {
@@ -149,6 +149,10 @@ describe('Mixpanel Forwarder', function () {
     var API_HOST = 'https://api.mixpanel.com';
 
     var identificationTypes = [
+        {
+            userIdentificationType: 'MPID',
+            expectedProperty: 'mpid1',
+        },
         {
             userIdentificationType: 'CustomerId',
             expectedProperty: 'cust1',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -148,7 +148,30 @@ describe('Mixpanel Forwarder', function () {
     }
     var API_HOST = 'https://api.mixpanel.com';
 
-    before(function () {
+    var identificationTypes = [
+        {
+            userIdentificationType: 'CustomerId',
+            expectedProperty: 'cust1',
+        },
+        {
+            userIdentificationType: 'Other',
+            expectedProperty: 'other1',
+        },
+        {
+            userIdentificationType: 'Other2',
+            expectedProperty: 'other2',
+        },
+        {
+            userIdentificationType: 'Other3',
+            expectedProperty: 'other3',
+        },
+        {
+            userIdentificationType: 'Other4',
+            expectedProperty: 'other4',
+        },
+    ];
+
+    beforeEach(function () {
         window.mixpanel = new MPMock();
         mParticle.forwarder.init(
             {
@@ -289,7 +312,6 @@ describe('Mixpanel Forwarder', function () {
         });
 
         it('should log in a user (mParticle SDK v2)', function (done) {
-
             var user = {
                 getUserIdentities: function () {
                     return {
@@ -307,53 +329,68 @@ describe('Mixpanel Forwarder', function () {
                 },
             };
 
-            var identificationTypes = [
-                {
-                    userIdentificationType: 'CustomerId',
-                    expectedProperty: 'cust1'
-                },
-                {
-                    userIdentificationType: 'Other',
-                    expectedProperty: 'other1'
-                },
-                {
-                    userIdentificationType: 'Other2',
-                    expectedProperty: 'other2'
-                },
-                {
-                    userIdentificationType: 'Other3',
-                    expectedProperty: 'other3'
-                },
-                {
-                    userIdentificationType: 'Other4',
-                    expectedProperty: 'other4'
-                },
-            ];
-
             identificationTypes.forEach(function (identificationType) {
                 mParticle.forwarder.init(
                     {
                         includeUserAttributes: 'True',
-                        userIdentificationType: identificationType.userIdentificationType
+                        userIdentificationType:
+                            identificationType.userIdentificationType,
                     },
                     reportService.cb,
                     true
                 );
-    
+
                 mParticle.forwarder.onLoginComplete(user);
                 window.mixpanel.mparticle.should.have.property(
                     'identifyCalled',
                     true
                 );
-                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
-
+                window.mixpanel.mparticle.should.have.property(
+                    'data',
+                    identificationType.expectedProperty
+                );
             });
 
             done();
         });
 
-        it('should identify a user (mParticle SDK v2)', function (done) {
+        it('should NOT log in a user if they do not have user identities (mParticle SDK v2)', function (done) {
+            var user = {
+                getUserIdentities: function () {
+                    return {
+                        userIdentities: {},
+                    };
+                },
+                getMPID: function () {
+                    return 'anon-mpid1';
+                },
+            };
 
+            identificationTypes.forEach(function (identificationType) {
+                mParticle.forwarder.init(
+                    {
+                        includeUserAttributes: 'True',
+                        userIdentificationType:
+                            identificationType.userIdentificationType,
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onLoginComplete(user);
+                window.mixpanel.mparticle.should.have.property(
+                    'identifyCalled',
+                    false
+                );
+                window.mixpanel.mparticle.should.not.have.property(
+                    'data',
+                    identificationType.expectedProperty
+                );
+            });
+            done();
+        });
+
+        it('should identify a user (mParticle SDK v2)', function (done) {
             var user = {
                 getUserIdentities: function () {
                     return {
@@ -371,53 +408,32 @@ describe('Mixpanel Forwarder', function () {
                 },
             };
 
-            var identificationTypes = [
-                {
-                    userIdentificationType: 'CustomerId',
-                    expectedProperty: 'cust1'
-                },
-                {
-                    userIdentificationType: 'Other',
-                    expectedProperty: 'other1'
-                },
-                {
-                    userIdentificationType: 'Other2',
-                    expectedProperty: 'other2'
-                },
-                {
-                    userIdentificationType: 'Other3',
-                    expectedProperty: 'other3'
-                },
-                {
-                    userIdentificationType: 'Other4',
-                    expectedProperty: 'other4'
-                },
-            ];
-
             identificationTypes.forEach(function (identificationType) {
                 mParticle.forwarder.init(
                     {
                         includeUserAttributes: 'True',
-                        userIdentificationType: identificationType.userIdentificationType
+                        userIdentificationType:
+                            identificationType.userIdentificationType,
                     },
                     reportService.cb,
                     true
                 );
-    
+
                 mParticle.forwarder.onIdentifyComplte(user);
                 window.mixpanel.mparticle.should.have.property(
                     'identifyCalled',
                     true
                 );
-                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
-
+                window.mixpanel.mparticle.should.have.property(
+                    'data',
+                    identificationType.expectedProperty
+                );
             });
 
             done();
         });
 
-        it('should modify a user\'s identity (mParticle SDK v2)', function (done) {
-
+        it('should modify a user identity (mParticle SDK v2)', function (done) {
             var user = {
                 getUserIdentities: function () {
                     return {
@@ -435,67 +451,43 @@ describe('Mixpanel Forwarder', function () {
                 },
             };
 
-            var identificationTypes = [
-                {
-                    userIdentificationType: 'CustomerId',
-                    expectedProperty: 'cust1'
-                },
-                {
-                    userIdentificationType: 'Other',
-                    expectedProperty: 'other1'
-                },
-                {
-                    userIdentificationType: 'Other2',
-                    expectedProperty: 'other2'
-                },
-                {
-                    userIdentificationType: 'Other3',
-                    expectedProperty: 'other3'
-                },
-                {
-                    userIdentificationType: 'Other4',
-                    expectedProperty: 'other4'
-                },
-            ];
-
             identificationTypes.forEach(function (identificationType) {
                 mParticle.forwarder.init(
                     {
                         includeUserAttributes: 'True',
-                        userIdentificationType: identificationType.userIdentificationType
+                        userIdentificationType:
+                            identificationType.userIdentificationType,
                     },
                     reportService.cb,
                     true
                 );
-    
+
                 mParticle.forwarder.onModifyComplete(user);
                 window.mixpanel.mparticle.should.have.property(
                     'identifyCalled',
                     true
                 );
-                window.mixpanel.mparticle.should.have.property('data', identificationType.expectedProperty);
-
+                window.mixpanel.mparticle.should.have.property(
+                    'data',
+                    identificationType.expectedProperty
+                );
             });
 
             done();
         });
 
         it('should log out a user (mParticle SDK v2)', function (done) {
-
             mParticle.forwarder.init(
                 {
                     includeUserAttributes: 'True',
-                    userIdentificationType: 'MPID'
+                    userIdentificationType: 'MPID',
                 },
                 reportService.cb,
                 true
             );
 
             mParticle.forwarder.onLogoutComplete();
-            window.mixpanel.mparticle.should.have.property(
-                'resetCalled',
-                true
-            );
+            window.mixpanel.mparticle.should.have.property('resetCalled', true);
 
             done();
         });


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - A bug was recently encountered where an anonymous profiles were not being merged with identified profiles in Mixpanel
 - This issue is attributed to the way mParticle handles anonymous users versus how Mixpanel handles them.
   - mParticle assigns all users a unique MPID, even if they are anonymous
   - Mixpanel uses a `device_id` to denote an anonymous user and a `user_id` for known users, and a third, `distinct_id` to bridge the gap.
 - When mParticle identifies an anonymous user, we currently send that MPID to Mixpanel's `identify` function as part of our Identify Request Callback. Mixpanel treats this MPID as the user's `user_id`, linking it with the user's `device_id`, and associates future events with the anonymous MPID as Mixpanel's `distinct_id`.
 - When mParticle then later identifies the user as a known user via a login or a subsequent identity request, it sends a new MPID to Mixpanel.identify as a `user_id`, but Mixpanel generates an error `$anon_distinct_id didn't match expected GUID pattern` and does not associate future events with the previous `user_id`.
 - This fix now will verify that an mParticle Identify request will not generate a Mixpanel identify request unless there is an actual mParticle user identity, denoting that the user is actually known. If the user is anonymous, mParticle will continue to associate events with the anonymous MPID, and will continue to forward events to Mixpanel, which will use their `device_id` to track anonymous events.
 - Once the user is correctly identified via mParticle as a known user, we will then send a request to Mixpanel's Identify function with an actual `user_id` that is known, allowing Mixpanel to correctly merge the profiles.
 - In this fix, we are also including an implementation of Mixpanel's `reset` method tied to mParticle's logout method, so that if a user formally logs out, their session is logged out via Mixpanel as per their requirements.
   - As per [Mixpanel's Identifying Users](https://docs.mixpanel.com/docs/tracking-methods/identifying-users) documentation, the recommended action is to call `reset()` on logout, so we are splitting `logout` from the other Identity methods so that `logout` properly triggers a `reset()`.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Set up a sample app with the Mixpanel Kit configured to use `MPID` as the **External Identity Type**
![Screenshot 2023-10-25 at 6 07 42 PM](https://github.com/mparticle-integrations/mparticle-javascript-integration-mixpanel/assets/49695018/4ae693e4-52e4-4ccb-8802-d17933b79333)
 - Send anonymous events and then perform a login.
 - Continue to fire events as a logged in user, and then log out.
 - Send more anonymous events, and then log back in as the same user.
 - You should no longer receive the initial error in the identify calls, and all events should be tied to the same user


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5895
