### PR TITLE
fix: Prevent event name prefix from being sent to Reporting Service

### DIFF
--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -91,7 +91,6 @@ var constructor = function () {
                 logEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {
                 reportEvent = true;
-                logEvent(event);
                 logPageView(event);
             } else if (
                 event.EventDataType == MessageType.Commerce &&

--- a/src/MixpanelEventForwarder.js
+++ b/src/MixpanelEventForwarder.js
@@ -90,9 +90,9 @@ var constructor = function () {
                 reportEvent = true;
                 logEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {
-                event.EventName = 'Viewed ' + event.EventName;
                 reportEvent = true;
                 logEvent(event);
+                logPageView(event);
             } else if (
                 event.EventDataType == MessageType.Commerce &&
                 event.ProductAction &&
@@ -294,6 +294,17 @@ var constructor = function () {
             }
         } catch (e) {
             return 'Cannot call unregister on forwarder: ' + name + ': ' + e;
+        }
+    }
+
+    function logPageView(event) {
+        var eventName = 'Viewed ' + event.EventName;
+        event.EventAttributes = event.EventAttributes || {};
+
+        try {
+            mixpanel.mparticle.track(eventName, event.EventAttributes);
+        } catch (e) {
+            return 'Cannot log event on forwarder: ' + name + ': ' + e;
         }
     }
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -275,6 +275,32 @@ describe('Mixpanel Forwarder', function () {
 
             done();
         });
+
+        it('should NOT alter the event name when sending a page view to the reporting service', function (done) {
+            mParticle.forwarder.process({
+                EventDataType: MessageType.PageView,
+                EventName: 'Test Page Event',
+            });
+
+            window.mixpanel.mparticle.should.have.property('trackCalled', true);
+            window.mixpanel.mparticle.data.should.be
+                .instanceof(Array)
+                .and.have.lengthOf(2);
+
+            window.mixpanel.mparticle.data[0].should.be.type('string');
+            window.mixpanel.mparticle.data[1].should.be.instanceof(Object);
+
+            window.mixpanel.mparticle.data[0].should.be.equal(
+                'Viewed Test Page Event'
+            );
+            window.mixpanel.mparticle.data[1].should.be.an
+                .Object()
+                .and.be.empty();
+
+            reportService.event.EventName.should.be.equal('Test Page Event');
+
+            done();
+        });
     });
 
     describe('User events', function () {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - At the time this kit was created, Mixpanel logged Page Views as standard events via their `track` method. As a workaround, we added a prefix of "Viewed" when sending these events to Mixpanel to allow customers to easily identify events as Page Views.
 - However, this prefix for event names does not allow event names to be properly tracked within the mParticle UI.
 - As a fix, we are only appending the prefix of "Viewed" when sending events to Mixpanel, but retaining the initial event name within mParticle.
 - Note: [Mixpanel now supports tracking pageviews](https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#tracking-page-views). This feature will be implemented in a future revision of this kit.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Using a sample app, log a page view event.
 - The event should appear in Mixpanel with a prefix of "Viewed", and the Event Forwarder Counts should increment.
 - However the event reporting payload should not contain the "Viewed" prefix.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5868
